### PR TITLE
adding version check around libxml_disable_entity_loader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,6 @@ jobs:
             - name: PHPStan
               run: composer phpstan
             - name: Code Style Check
-              env:
-                  PHP_CS_FIXER_IGNORE_ENV: true
               run: composer style-check -- --format=checkstyle | cs2pr
             - name: Test
               run: composer test-with-coverage

--- a/.php_cs
+++ b/.php_cs
@@ -16,7 +16,7 @@ return PhpCsFixer\Config::create()
         'single_quote'              => true,
         'array_syntax'              => array('syntax' => 'long'),
         'concat_space'              => array('spacing' => 'one'),
-        'psr0'                      => true
+        'psr0'                      => false
     ))
     ->setUsingCache(true)
     ->setFinder($finder);

--- a/.php_cs
+++ b/.php_cs
@@ -16,7 +16,7 @@ return PhpCsFixer\Config::create()
         'single_quote'              => true,
         'array_syntax'              => array('syntax' => 'long'),
         'concat_space'              => array('spacing' => 'one'),
-        'psr0'                      => false
+        'psr0'                      => true
     ))
     ->setUsingCache(true)
     ->setFinder($finder);

--- a/src/Zend/Xml/Security.php
+++ b/src/Zend/Xml/Security.php
@@ -84,7 +84,9 @@ class Zend_Xml_Security
         }
 
         if (!self::isPhpFpm()) {
-            $loadEntities         = libxml_disable_entity_loader(true);
+            if (version_compare(PHP_VERSION, '8.0.0', 'lt')) {
+                $loadEntities = libxml_disable_entity_loader(true);
+            }
             $useInternalXmlErrors = libxml_use_internal_errors(true);
         }
 
@@ -98,7 +100,9 @@ class Zend_Xml_Security
         if (!$result) {
             // Entity load to previous setting
             if (!self::isPhpFpm()) {
-                libxml_disable_entity_loader($loadEntities);
+                if (version_compare(PHP_VERSION, '8.0.0', 'lt')) {
+                    libxml_disable_entity_loader($loadEntities);
+                }
                 libxml_use_internal_errors($useInternalXmlErrors);
             }
             return false;
@@ -120,7 +124,9 @@ class Zend_Xml_Security
 
         // Entity load to previous setting
         if (!self::isPhpFpm()) {
-            libxml_disable_entity_loader($loadEntities);
+            if (version_compare(PHP_VERSION, '8.0.0', 'lt')) {
+                libxml_disable_entity_loader($loadEntities);
+            }
             libxml_use_internal_errors($useInternalXmlErrors);
         }
 


### PR DESCRIPTION
When testing zf1-config, PHP 8 threw some deprecation notices in the test suite of that package. `libxml_disable_entity_loader` (https://www.php.net/manual/en/function.libxml-disable-entity-loader.php) has been deprecated in PHP 8 since libxml has been updated to the version that disables the entity loader by default.

https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation

This PR wraps the calls to `libxml_disable_entity_loader` with a version check, preventing the call to this function in PHP 8 and above. It's still required to call it in PHP 7 and below.

zf1-config passes with this change in place in all version of PHP: https://github.com/diablomedia/zf1-config/pull/85/checks